### PR TITLE
Changed ignored-paths.js to exclude .eslintignore patterns from globb…

### DIFF
--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -18,7 +18,6 @@ var lodash = require("lodash"),
 
 debug = debug("eslint:ignored-paths");
 
-
 //------------------------------------------------------------------------------
 // Constants
 //------------------------------------------------------------------------------
@@ -33,11 +32,9 @@ var DEFAULT_OPTIONS = {
     cwd: process.cwd()
 };
 
-
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
-
 
 /**
  * Find an ignore file in the current directory.
@@ -157,12 +154,16 @@ function IgnoredPaths(options) {
             this.baseDir = path.dirname(path.resolve(options.cwd, ignorePath));
             addIgnoreFile(this.ig.custom, ignorePath);
             addIgnoreFile(this.ig.default, ignorePath);
-            
+
             // Add all lines from the ignorePath to the ignoredPaths var, so we can exclude them from glob later.
             this.ignoredPatterns = this.ignoredPatterns.concat(
-                fs.readFileSync(ignorePath, { encoding: 'utf8' }).split('\n')
-                    .map(function(x) { return x.trim(); })
-                    .filter(function(x) { return !/^\s*#/.test(x); })
+                fs.readFileSync(ignorePath, { encoding: "utf8" }).split("\n")
+                    .map(function(x) {
+                        return x.trim();
+                    })
+                    .filter(function(x) {
+                        return !/^\s*#/.test(x);
+                    })
             );
         }
 
@@ -225,7 +226,6 @@ IgnoredPaths.prototype.getIgnoredFoldersGlobPatterns = function() {
             });
         });
     }
-
 
     return dirs.map(function(dir) {
         return dir + "**";

--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -107,6 +107,9 @@ function IgnoredPaths(options) {
         default: ignore()
     };
 
+    // This keeps track of ignore patterns coming from the .eslintignore file.
+    this.ignoredPatterns = [];
+
     // Add a way to keep track of ignored files.  This was present in node-ignore
     // 2.x, but dropped for now as of 3.0.10.
     this.ig.custom.ignoreFiles = [];
@@ -154,6 +157,13 @@ function IgnoredPaths(options) {
             this.baseDir = path.dirname(path.resolve(options.cwd, ignorePath));
             addIgnoreFile(this.ig.custom, ignorePath);
             addIgnoreFile(this.ig.default, ignorePath);
+            
+            // Add all lines from the ignorePath to the ignoredPaths var, so we can exclude them from glob later.
+            this.ignoredPatterns = this.ignoredPatterns.concat(
+                fs.readFileSync(ignorePath, { encoding: 'utf8' }).split('\n')
+                    .map(function(x) { return x.trim(); })
+                    .filter(function(x) { return !/^\s*#/.test(x); })
+            );
         }
 
         if (options.ignorePattern) {
@@ -219,7 +229,7 @@ IgnoredPaths.prototype.getIgnoredFoldersGlobPatterns = function() {
 
     return dirs.map(function(dir) {
         return dir + "**";
-    });
+    }).concat(this.ignoredPatterns); // Also include patterns from the ignorePath files.
 };
 
 module.exports = IgnoredPaths;


### PR DESCRIPTION
…ing (improves performance).

**What issue does this pull request address?**
https://github.com/eslint/eslint/issues/6710

**What changes did you make? (Give an overview)**
When we read .eslintignore files, I add each non-commented line to "ignorePatterns", and then exclude those from globbing later.  The goal is to eliminate globbing ignored files (just like we do with DEFAULT_IGNORE_DIRS already) for faster performance.

**Is there anything you'd like reviewers to focus on?**
Is there a better/cleaner way to do this?
